### PR TITLE
Free TLS mbufs using the sbtls workers.

### DIFF
--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -678,6 +678,7 @@ extern uma_zone_t	zone_pack;
 extern uma_zone_t	zone_jumbop;
 extern uma_zone_t	zone_jumbo9;
 extern uma_zone_t	zone_jumbo16;
+extern uma_zone_t	zone_extpgs;
 
 void		 mb_dupcl(struct mbuf *, struct mbuf *);
 void		 mb_free_ext(struct mbuf *);

--- a/sys/sys/sockbuf_tls.h
+++ b/sys/sys/sockbuf_tls.h
@@ -228,6 +228,11 @@ sbtls_enqueue(struct mbuf *m, struct socket *so, int page_count)
 }
 
 static inline void
+sbtls_enqueue_to_free(struct mbuf_ext_pgs *pgs)
+{
+}
+
+static inline void
 sbtls_seq(struct sockbuf *sb, struct mbuf *m)
 {
 }
@@ -244,7 +249,7 @@ int sbtls_frame(struct mbuf **m, struct socket *so, int *enqueue_cnt,
     uint8_t record_type);
 void sbtls_seq(struct sockbuf *sb, struct mbuf *m);
 void sbtls_enqueue(struct mbuf *m, struct socket *so, int page_count);
-
+void sbtls_enqueue_to_free(void *arg);
 
 #endif /* KERN_TLS */
 #endif /* _KERNEL */


### PR DESCRIPTION
Using a single taskqueue creates lock contention on the
extpgs free lock, and on the tq thread lock:

Adaptive mutex spin: 1800410 events in 5.033 seconds (357723 events/sec)

Count indv cuml rcnt     nsec Lock                   Caller
-------------------------------------------------------------------------------
1019295  57%  57% 0.00     7818 extpgs free            mb_free_ext+0x1e7
196236  11%  68% 0.00     3116 thread                 taskqueue_enqueue+0x98

We already have a work queue with ncpu threads to do TLS
encryption in software.  Use that rather than creating more
taskqueue threads.

While here, fix the lack of a proper VNET wrapper in an error case.